### PR TITLE
Use LIBRARY_PATH to have ld look for libgccjit at link time

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -6,6 +6,8 @@ set -e
 export GCC_PATH=$(cat gcc_path)
 
 export LD_LIBRARY_PATH="$GCC_PATH"
+export LIBRARY_PATH="$GCC_PATH"
+
 if [[ "$1" == "--release" ]]; then
     export CHANNEL='release'
     CARGO_INCREMENTAL=1 cargo rustc --release


### PR DESCRIPTION
LD_LIBRARY_PATH is used at runtime whereas LIBRARY_PATH is used during linking.
Without it, I get:

  = note: /usr/bin/ld: cannot find -lgccjit
          collect2: error: ld returned 1 exit status

during the `cargo rustc` in `test.sh`