### PR TITLE
Send llvm-args to libgccjit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ harness = false
 [dependencies]
 gccjit = { git = "https://github.com/antoyo/gccjit.rs" }
 
+# Local copy.
+#gccjit = { path = "../gccjit.rs" }
+
 target-lexicon = "0.10.0"
 
 ar = "0.8.0"

--- a/src/base.rs
+++ b/src/base.rs
@@ -75,6 +75,9 @@ pub fn compile_codegen_unit<'tcx>(tcx: TyCtxt<'tcx>, cgu_name: Symbol) -> (Modul
         let context = Context::default();
         // TODO: only set on x86 platforms.
         context.add_command_line_option("-masm=intel");
+        for arg in &tcx.sess.opts.cg.llvm_args {
+            context.add_command_line_option(arg);
+        }
         //context.set_dump_code_on_compile(true);
         if env::var("CG_GCCJIT_DUMP_GIMPLE").as_deref() == Ok("1") {
             context.set_dump_initial_gimple(true);


### PR DESCRIPTION
Fix #44.

@dkm : It could be tricky to get the results, not only because they'll be in `/tmp`, but also because of CGUs: you'll have multiple temp directory to look at.