### PR TITLE
Remove pass test from the list

### DIFF
--- a/tests/failing-ui-tests.txt
+++ b/tests/failing-ui-tests.txt
@@ -57,7 +57,6 @@ tests/ui/lto/msvc-imp-present.rs
 tests/ui/lto/lto-thin-rustc-loads-linker-plugin.rs
 tests/ui/lto/all-crates.rs
 tests/ui/async-await/deep-futures-are-freeze.rs
-tests/ui/panic-runtime/lto-abort.rs
 tests/ui/closures/capture-unsized-by-ref.rs
 tests/ui/coroutine/resume-after-return.rs
 tests/ui/macros/rfc-2011-nicer-assert-messages/all-expr-kinds.rs

--- a/tests/failing-ui-tests.txt
+++ b/tests/failing-ui-tests.txt
@@ -57,6 +57,7 @@ tests/ui/lto/msvc-imp-present.rs
 tests/ui/lto/lto-thin-rustc-loads-linker-plugin.rs
 tests/ui/lto/all-crates.rs
 tests/ui/async-await/deep-futures-are-freeze.rs
+tests/ui/panic-runtime/lto-abort.rs
 tests/ui/closures/capture-unsized-by-ref.rs
 tests/ui/coroutine/resume-after-return.rs
 tests/ui/macros/rfc-2011-nicer-assert-messages/all-expr-kinds.rs

--- a/tests/failing-ui-tests.txt
+++ b/tests/failing-ui-tests.txt
@@ -16,10 +16,8 @@ tests/ui/sepcomp/sepcomp-statics.rs
 tests/ui/asm/x86_64/may_unwind.rs
 tests/ui/backtrace.rs
 tests/ui/catch-unwind-bang.rs
-tests/ui/cfg/cfg-panic-abort.rs
 tests/ui/drop/dynamic-drop-async.rs
 tests/ui/drop/repeat-drop.rs
-tests/ui/fmt/format-args-capture.rs
 tests/ui/coroutine/panic-drops-resume.rs
 tests/ui/coroutine/panic-drops.rs
 tests/ui/intrinsics/panic-uninitialized-zeroed.rs
@@ -29,9 +27,7 @@ tests/ui/mir/mir_calls_to_shims.rs
 tests/ui/mir/mir_drop_order.rs
 tests/ui/mir/mir_let_chains_drop_order.rs
 tests/ui/oom_unwind.rs
-tests/ui/panic-runtime/abort-link-to-unwinding-crates.rs
 tests/ui/panic-runtime/abort.rs
-tests/ui/panic-runtime/link-to-abort.rs
 tests/ui/unwind-no-uwtable.rs
 tests/ui/parser/unclosed-delimiter-in-dep.rs
 tests/ui/runtime/rt-explody-panic-payloads.rs

--- a/tests/failing-ui-tests.txt
+++ b/tests/failing-ui-tests.txt
@@ -2,7 +2,6 @@ tests/ui/allocator/no_std-alloc-error-handler-custom.rs
 tests/ui/allocator/no_std-alloc-error-handler-default.rs
 tests/ui/asm/may_unwind.rs
 tests/ui/asm/x86_64/multiple-clobber-abi.rs
-tests/ui/debuginfo/debuginfo-emit-llvm-ir-and-split-debuginfo.rs
 tests/ui/functions-closures/parallel-codegen-closures.rs
 tests/ui/linkage-attr/linkage1.rs
 tests/ui/lto/dylib-works.rs
@@ -27,7 +26,6 @@ tests/ui/mir/mir_calls_to_shims.rs
 tests/ui/mir/mir_drop_order.rs
 tests/ui/mir/mir_let_chains_drop_order.rs
 tests/ui/oom_unwind.rs
-tests/ui/panic-runtime/abort.rs
 tests/ui/unwind-no-uwtable.rs
 tests/ui/parser/unclosed-delimiter-in-dep.rs
 tests/ui/runtime/rt-explody-panic-payloads.rs
@@ -44,8 +42,6 @@ tests/ui/rfcs/rfc-1857-stabilize-drop-order/drop-order.rs
 tests/ui/rfcs/rfc-2091-track-caller/std-panic-locations.rs
 tests/ui/simd/issue-17170.rs
 tests/ui/simd/issue-39720.rs
-tests/ui/statics/issue-91050-1.rs
-tests/ui/statics/issue-91050-2.rs
 tests/ui/alloc-error/default-alloc-error-hook.rs
 tests/ui/coroutine/panic-safe.rs
 tests/ui/issues/issue-14875.rs
@@ -53,7 +49,6 @@ tests/ui/issues/issue-29948.rs
 tests/ui/panics/nested_panic_caught.rs
 tests/ui/const_prop/ice-issue-111353.rs
 tests/ui/process/println-with-broken-pipe.rs
-tests/ui/panic-runtime/lto-abort.rs
 tests/ui/lto/thin-lto-inlines2.rs
 tests/ui/lto/weak-works.rs
 tests/ui/lto/thin-lto-inlines.rs


### PR DESCRIPTION
Remove pass test PR
tests/ui/cfg/cfg-panic-abort.rs
tests/ui/fmt/format-args-capture.rs
tests/ui/panic-runtime/link-to-abort.rs
tests/ui/panic-runtime/abort-link-to-unwinding-crates.rs
tests/ui/panic-runtime/abort.rs
tests/ui/statics/issue-91050-1.rs
tests/ui/statics/issue-91050-2.rs
tests/ui/debuginfo/debuginfo-emit-llvm-ir-and-split-debuginfo.rs
tests/ui/panic-runtime/lto-abort.rs

