### PR TITLE
CI cargo test added

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,11 @@ jobs:
     - name: Run tests
       run: |
         ./y.sh test --release --clean --build-sysroot ${{ matrix.commands }}
+      
+    - name: Run y.sh cargo build
+      run: |
+        chmod +x ./y.sh
+        ./y.sh cargo build    
 
     - name: Check formatting
       run: cargo fmt -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,14 @@ jobs:
         ./y.sh prepare --only-libcore
         ./y.sh build
         cargo test
-        ./y.sh clean all
+
+    - name: Run y.sh cargo build
+      run: |
+        ./y.sh cargo build --manifest-path tests/hello-world/Cargo.toml
+
+    - name: Clean
+      run: |
+        ./y.sh clean all      
 
     - name: Prepare dependencies
       run: |
@@ -94,11 +101,6 @@ jobs:
     - name: Run tests
       run: |
         ./y.sh test --release --clean --build-sysroot ${{ matrix.commands }}
-      
-    - name: Run y.sh cargo build
-      run: |
-        export RUSTFLAGS="-Zcodegen-backend=$(pwd)/target/release/librustc_codegen_gcc.so"
-        ./y.sh cargo build --manifest-path tests/hello_world/Cargo.toml
 
     - name: Check formatting
       run: cargo fmt -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,6 @@ jobs:
       
     - name: Run y.sh cargo build
       run: |
-        chmod +x ./y.sh
         ./y.sh cargo build    
 
     - name: Check formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
       
     - name: Run y.sh cargo build
       run: |
-        ./y.sh cargo build    
+        ./y.sh cargo build --manifest-path tests/hello-world/Cargo.toml   
 
     - name: Check formatting
       run: cargo fmt -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,8 @@ jobs:
       
     - name: Run y.sh cargo build
       run: |
-        ./y.sh cargo build --manifest-path tests/hello-world/Cargo.toml   
+        export RUSTFLAGS="-Zcodegen-backend=$(pwd)/target/release/librustc_codegen_gcc.so"
+        ./y.sh cargo build --manifest-path tests/hello_world/Cargo.toml
 
     - name: Check formatting
       run: cargo fmt -- --check

--- a/tests/hello-world/Cargo.toml
+++ b/tests/hello-world/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "hello_world"
+
+[dependencies]

--- a/tests/hello-world/src/main.rs
+++ b/tests/hello-world/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}


### PR DESCRIPTION
- Resolves https://github.com/rust-lang/rustc_codegen_gcc/issues/400
- Adds test in CI for ```./y.sh cargo build```