### PR TITLE
Default to `download-gccjit` instead of `gcc-path`

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -1,2 +1,2 @@
-gcc-path = "gcc-build/gcc"
-# download-gccjit = true
+#gcc-path = "gcc-build/gcc"
+download-gccjit = true


### PR DESCRIPTION
In the `Readme.md` file, we say that if you don't need to test your own `gccjit` patches, the default config should be all good... except it was doing the opposite. This fixes it.